### PR TITLE
Fix cidrize subnet handling

### DIFF
--- a/ipcheck.py
+++ b/ipcheck.py
@@ -72,8 +72,12 @@ def validate_subnet(subnet):
                 except:
                     try:
                         cidrip = cidrize(subnet)
-                        subbed = ipaddress.ip_network(cidrip)
-                        return subbed
+                        if cidrip:
+                            for cidr in cidrip:
+                                subbed = ipaddress.ip_network(str(cidr))
+                                return subbed
+                        else:
+                            raise ValueError('cidrize returned no results')
                     except:
                         msg = 'Subnet %s is not valid CIDR syntax, cannot process!' % (subnet)
                         print(msg)


### PR DESCRIPTION
## Summary
- handle lists returned by `cidrize` when validating subnets

## Testing
- `python3 ipcheck.py -h`
- `python3 -m py_compile ipcheck.py`
- `python3 ipcheck.py -i 192.168.1.210 -s 192.168.1.0/24`
- `python3 ipcheck.py -i 192.168.1.1 -s "192.168.1.*"`
- `python3 ipcheck.py -i 192.168.1.1 -s badsubnet`


------
https://chatgpt.com/codex/tasks/task_e_686c5318b40c8326a741f64676c69d8f